### PR TITLE
Breaking: Drop support for Node.js < v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "0.12"
     - "4"
     - "5"
     - "6"


### PR DESCRIPTION
This will make #5 easier. No intentional move will be made to break Node versions earlier than v4, but the library will no longer be tested on previous versions, and there will be no additional effort to support them. Put another way, I won't immediately rewrite the library in ES6, so it may or may not happen to work on previous versions, but if I feel like using `const` in a future change, I will.