### PR TITLE
Remove Node.js v5 from CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ addons:
             - g++-4.8
 node_js:
     - "4"
-    - "5"
     - "6"
     - "7"
 before_install:


### PR DESCRIPTION
Versions 4, 6, and 7 are the currently-supported releases:
https://github.com/nodejs/LTS/tree/1a10c515de897ea3ad73f6c2d7e4d145be0b27c5